### PR TITLE
Add support to PNC2

### DIFF
--- a/src/main/java/com/redhat/red/build/finder/BuildFinder.java
+++ b/src/main/java/com/redhat/red/build/finder/BuildFinder.java
@@ -61,7 +61,7 @@ import org.infinispan.manager.EmbeddedCacheManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.redhat.red.build.finder.pnc.client.PncClient14;
+import com.redhat.red.build.finder.pnc.client.PncClient;
 import com.redhat.red.build.finder.pnc.client.PncClientException;
 import com.redhat.red.build.finder.pnc.client.PncUtils;
 import com.redhat.red.build.finder.pnc.client.model.Artifact;
@@ -127,7 +127,7 @@ public class BuildFinder implements Callable<Map<BuildSystemInteger, KojiBuild>>
 
     private EmbeddedCacheManager cacheManager;
 
-    private PncClient14 pncclient;
+    private PncClient pncclient;
 
     private Map<Checksum, Collection<String>> foundChecksums;
 
@@ -145,7 +145,7 @@ public class BuildFinder implements Callable<Map<BuildSystemInteger, KojiBuild>>
         this(session, config, analyzer, cacheManager, null);
     }
 
-    public BuildFinder(ClientSession session, BuildConfig config, DistributionAnalyzer analyzer, EmbeddedCacheManager cacheManager, PncClient14 pncclient) {
+    public BuildFinder(ClientSession session, BuildConfig config, DistributionAnalyzer analyzer, EmbeddedCacheManager cacheManager, PncClient pncclient) {
         this.session = session;
         this.config = config;
         this.outputDirectory = new File("");

--- a/src/main/java/com/redhat/red/build/finder/BuildSystem.java
+++ b/src/main/java/com/redhat/red/build/finder/BuildSystem.java
@@ -18,9 +18,10 @@ package com.redhat.red.build.finder;
 public enum BuildSystem {
     none(0),
     koji(1),
-    pnc(2);
+    pnc(2),
+    pnc2(3);
 
-    private int value;
+    private final int value;
 
     BuildSystem(int value) {
         this.value = value;

--- a/src/main/java/com/redhat/red/build/finder/Main.java
+++ b/src/main/java/com/redhat/red/build/finder/Main.java
@@ -53,7 +53,8 @@ import org.infinispan.manager.EmbeddedCacheManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.redhat.red.build.finder.pnc.client.PncClient14;
+import com.redhat.red.build.finder.pnc.client.PncClient;
+import com.redhat.red.build.finder.pnc.client.PncClientFactory;
 import com.redhat.red.build.finder.report.BuildStatisticsReport;
 import com.redhat.red.build.finder.report.GAVReport;
 import com.redhat.red.build.finder.report.HTMLReport;
@@ -607,7 +608,7 @@ public final class Main implements Callable<Void> {
                     analyzer.setChecksums(checksums);
 
                     if (config.getPncURL() != null) {
-                        PncClient14 pncclient = new PncClient14(config);
+                        PncClient pncclient = PncClientFactory.create(config);
                         finder = new BuildFinder(session, config, analyzer, cacheManager, pncclient);
                     } else {
                         finder = new BuildFinder(session, config, analyzer, cacheManager);
@@ -649,7 +650,7 @@ public final class Main implements Callable<Void> {
                     }
 
                     if (config.getPncURL() != null) {
-                        PncClient14 pncclient = new PncClient14(config);
+                        PncClient pncclient = PncClientFactory.create(config);
                         finder = new BuildFinder(session, config, analyzer, cacheManager, pncclient);
                     } else {
                         finder = new BuildFinder(session, config, analyzer, cacheManager);

--- a/src/main/java/com/redhat/red/build/finder/pnc/client/BasePncClient.java
+++ b/src/main/java/com/redhat/red/build/finder/pnc/client/BasePncClient.java
@@ -1,0 +1,365 @@
+/*
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.redhat.red.build.finder.pnc.client;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import org.apache.commons.collections4.ListUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.mashape.unirest.http.HttpResponse;
+import com.mashape.unirest.http.ObjectMapper;
+import com.mashape.unirest.http.Unirest;
+import com.mashape.unirest.http.exceptions.UnirestException;
+import com.redhat.red.build.finder.BuildConfig;
+import com.redhat.red.build.finder.pnc.client.model.Artifact;
+import com.redhat.red.build.finder.pnc.client.model.BuildRecordPushResult;
+import com.redhat.red.build.finder.pnc.client.model.PageParameterArtifact;
+import com.redhat.red.build.finder.pnc.client.model.PageParameterBuildRecordPushResult;
+import com.redhat.red.build.finder.pnc.client.model.PageParameterProductVersion;
+import com.redhat.red.build.finder.pnc.client.model.ProductVersion;
+
+/**
+ * Base {@link PncClient} class with common methods between PNC1 and PNC2
+ */
+abstract class BasePncClient implements PncClient {
+    private static final Logger LOGGER = LoggerFactory.getLogger(BasePncClient.class);
+
+    private final BuildConfig config;
+
+    /**
+     * Create a new PncClient14 object
+     *
+     * @param config the build configuration
+     */
+    BasePncClient(BuildConfig config) {
+        this.config = config;
+        unirestSetup();
+        Unirest.setTimeouts(config.getPncConnectionTimeout(), config.getPncReadTimeout());
+    }
+
+    /**
+     * Setup Unirest to automatically convert JSON into DTO
+     */
+    private static void unirestSetup() {
+        Unirest.setObjectMapper(new ObjectMapper() {
+            private final com.fasterxml.jackson.databind.ObjectMapper jacksonObjectMapper = new com.fasterxml.jackson.databind.ObjectMapper()
+                .registerModule(new JavaTimeModule());
+
+            public <T> T readValue(String value, Class<T> valueType) {
+                try {
+                    return value == null || value.trim().isEmpty()
+                           ? null : //return null if the server fails to reply (status=404/500)
+                           jacksonObjectMapper.readValue(value, valueType);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            public String writeValue(Object value) {
+                try {
+                    return jacksonObjectMapper.writeValueAsString(value);
+                } catch (JsonProcessingException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+    }
+
+    @Override
+    public final List<Artifact> getArtifactsByMd5(String value) throws PncClientException {
+        return getArtifacts("md5", value);
+    }
+
+
+    @Override
+    public final List<Artifact> getArtifactsBySha1(String value) throws PncClientException {
+        return getArtifacts("sha1", value);
+    }
+
+
+    @Override
+    public final List<Artifact> getArtifactsBySha256(String value) throws PncClientException {
+        return getArtifacts("sha256", value);
+    }
+
+    @Override
+    public final List<List<Artifact>> getArtifactsByMd5(List<String> values) throws PncClientException {
+        return getArtifactsSplit(values, "md5");
+    }
+
+    @Override
+    public final List<List<Artifact>> getArtifactsBySha1(List<String> values) throws PncClientException {
+        return getArtifactsSplit(values, "sha1");
+    }
+
+    @Override
+    public final List<List<Artifact>> getArtifactsBySha256(List<String> values) throws PncClientException {
+        return getArtifactsSplit(values, "sha256");
+    }
+
+    @Override
+    public final List<Artifact> getBuiltArtifactsById(int id) throws PncClientException {
+        try {
+            String urlRequest = getBuiltArtifactsByIdUrl(id);
+            HttpResponse<PageParameterArtifact> artifacts = Unirest.get(urlRequest)
+                                                                   .asObject(PageParameterArtifact.class);
+            PageParameterArtifact artifactData = artifacts.getBody();
+
+            if (artifactData == null) {
+                return Collections.emptyList();
+            } else {
+                return artifactData.getContent();
+            }
+
+        } catch (UnirestException e) {
+            throw new PncClientException(e);
+        }
+    }
+
+    abstract String getBuiltArtifactsByIdUrl(int id);
+
+    @Override
+    public final List<List<Artifact>> getBuiltArtifactsById(List<Integer> ids) throws PncClientException {
+        List<List<Artifact>> artifactList = new ArrayList<>(ids.size());
+        List<Future<HttpResponse<PageParameterArtifact>>> futures = new ArrayList<>(ids.size());
+
+        for (Integer id : ids) {
+            String urlRequest = getBuiltArtifactsByIdUrl(id);
+            Future<HttpResponse<PageParameterArtifact>> artifactFuture = Unirest.get(urlRequest).asObjectAsync(
+                PageParameterArtifact.class);
+            futures.add(artifactFuture);
+        }
+
+        for (Future<HttpResponse<PageParameterArtifact>> artifact : futures) {
+            try {
+                HttpResponse<PageParameterArtifact> artifacts = artifact.get();
+                PageParameterArtifact artifactData = artifacts.getBody();
+
+                if (artifactData == null) {
+                    artifactList.add(Collections.emptyList());
+                } else {
+                    artifactList.add(artifactData.getContent());
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } catch (ExecutionException e) {
+                throw new PncClientException(e);
+            }
+        }
+
+        return artifactList;
+    }
+
+    @Override
+    public final BuildRecordPushResult getBuildRecordPushResultById(int id) throws PncClientException {
+        try {
+            String urlRequest = getBuildRecordPushResultByIdUrl(id);
+            HttpResponse<PageParameterBuildRecordPushResult> buildRecordPushResults = Unirest.get(urlRequest).asObject(
+                PageParameterBuildRecordPushResult.class);
+            PageParameterBuildRecordPushResult buildRecordPushResultData = buildRecordPushResults.getBody();
+
+            if (buildRecordPushResultData == null) {
+                return null;
+            } else {
+                return buildRecordPushResultData.getContent();
+            }
+        } catch (UnirestException e) {
+            throw new PncClientException(e);
+        }
+    }
+
+    abstract String getBuildRecordPushResultByIdUrl(int id);
+
+
+    @Override
+    public final ProductVersion getProductVersionById(int id) throws PncClientException {
+        try {
+            String urlRequest = getProductVersionByIdUrl(id);
+            HttpResponse<PageParameterProductVersion> buildConfigurations = Unirest.get(urlRequest).asObject(
+                PageParameterProductVersion.class);
+            PageParameterProductVersion buildConfigurationData = buildConfigurations.getBody();
+
+            if (buildConfigurationData == null) {
+                return null;
+            } else {
+                return buildConfigurationData.getContent();
+            }
+        } catch (UnirestException e) {
+            throw new PncClientException(e);
+        }
+    }
+
+    abstract String getProductVersionByIdUrl(int id);
+
+    @Override
+    public final List<ProductVersion> getProductVersionsById(List<Integer> ids) throws PncClientException {
+        List<Future<HttpResponse<PageParameterProductVersion>>> futures = new ArrayList<>(ids.size());
+
+        for (Integer id : ids) {
+            String urlRequest = getProductVersionByIdUrl(id);
+            Future<HttpResponse<PageParameterProductVersion>> buildConfigurationFuture = Unirest.get(urlRequest)
+                                                                                                .asObjectAsync(
+                                                                                                    PageParameterProductVersion.class);
+            futures.add(buildConfigurationFuture);
+        }
+
+        List<ProductVersion> buildConfigurationList = new ArrayList<>(ids.size());
+
+        for (Future<HttpResponse<PageParameterProductVersion>> future : futures) {
+
+            try {
+                HttpResponse<PageParameterProductVersion> buildConfiguration = future.get();
+                PageParameterProductVersion buildConfigurationData = buildConfiguration.getBody();
+
+                if (buildConfigurationData == null) {
+                    buildConfigurationList.add(null);
+                } else {
+                    buildConfigurationList.add(buildConfigurationData.getContent());
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } catch (ExecutionException e) {
+                throw new PncClientException(e);
+            }
+        }
+
+        return buildConfigurationList;
+    }
+
+    @Override
+    public final List<BuildRecordPushResult> getBuildRecordPushResultsById(List<Integer> ids)
+        throws PncClientException {
+        List<Future<HttpResponse<PageParameterBuildRecordPushResult>>> futures = new ArrayList<>(ids.size());
+
+        for (Integer id : ids) {
+            String urlRequest = getBuildRecordPushResultByIdUrl(id);
+            Future<HttpResponse<PageParameterBuildRecordPushResult>> buildRecordFuture = Unirest.get(urlRequest)
+                                                                                                .asObjectAsync(
+                                                                                                    PageParameterBuildRecordPushResult.class);
+            futures.add(buildRecordFuture);
+        }
+
+        List<BuildRecordPushResult> buildRecordPushResultList = new ArrayList<>(ids.size());
+
+        for (Future<HttpResponse<PageParameterBuildRecordPushResult>> future : futures) {
+
+            try {
+                HttpResponse<PageParameterBuildRecordPushResult> buildRecordPushResultData = future.get();
+                PageParameterBuildRecordPushResult buildRecordData = buildRecordPushResultData.getBody();
+
+                if (buildRecordData == null) {
+                    buildRecordPushResultList.add(null);
+                } else {
+                    buildRecordPushResultList.add(buildRecordData.getContent());
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } catch (ExecutionException e) {
+                throw new PncClientException(e);
+            }
+        }
+
+        return buildRecordPushResultList;
+    }
+
+    private List<List<Artifact>> getArtifactsSplit(List<String> values, String key) throws PncClientException {
+        int size = values.size();
+        int partitionSize = config.getPncPartitionSize();
+        List<List<Artifact>> result = new ArrayList<>(size);
+        List<List<String>> splitValues = ListUtils.partition(values, partitionSize);
+
+        for (List<String> splitValue : splitValues) {
+            int keysSize = splitValue.size();
+            List<String> keys = Collections.nCopies(keysSize, key);
+            List<List<Artifact>> artifacts = getArtifacts(keys, splitValue);
+            result.addAll(artifacts);
+        }
+
+        return result;
+    }
+
+    private List<List<Artifact>> getArtifacts(List<String> keys, List<String> values) throws PncClientException {
+        if (keys.size() != values.size()) {
+            throw new PncClientException("Mismatched keys and values sizes");
+        }
+
+        List<List<Artifact>> artifactsList = new ArrayList<>(values.size());
+        List<Future<HttpResponse<PageParameterArtifact>>> futures = new ArrayList<>(values.size());
+        int size = keys.size();
+
+        for (int i = 0; i < size; i++) {
+            String key = keys.get(i);
+            String value = values.get(i);
+            String urlRequest = getArtifactsUrl(key, value);
+            LOGGER.debug("key={}, value={}, urlRequest={}", key, value, urlRequest);
+            Future<HttpResponse<PageParameterArtifact>> artifacts = Unirest.get(urlRequest)
+                                                                           .asObjectAsync(PageParameterArtifact.class);
+            futures.add(artifacts);
+        }
+
+        for (Future<HttpResponse<PageParameterArtifact>> artifact : futures) {
+            try {
+                HttpResponse<PageParameterArtifact> artifacts = artifact.get();
+                PageParameterArtifact artifactData = artifacts.getBody();
+
+                if (artifactData == null) {
+                    artifactsList.add(Collections.emptyList());
+                } else {
+                    artifactsList.add(artifactData.getContent());
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } catch (ExecutionException e) {
+                throw new PncClientException(e);
+            }
+        }
+
+        return artifactsList;
+    }
+
+    private List<Artifact> getArtifacts(String key, String value) throws PncClientException {
+        try {
+            String urlRequest = getArtifactsUrl(key, value);
+            HttpResponse<PageParameterArtifact> artifacts = Unirest.get(urlRequest)
+                                                                   .asObject(PageParameterArtifact.class);
+            PageParameterArtifact artifactData = artifacts.getBody();
+
+            if (artifactData == null) {
+                return Collections.emptyList();
+            } else {
+                return artifactData.getContent();
+            }
+        } catch (UnirestException e) {
+            throw new PncClientException(e);
+        }
+
+    }
+
+    abstract String getArtifactsUrl(String checksumMethod, String value);
+
+    BuildConfig getConfig() {
+        return config;
+    }
+}

--- a/src/main/java/com/redhat/red/build/finder/pnc/client/PncClient.java
+++ b/src/main/java/com/redhat/red/build/finder/pnc/client/PncClient.java
@@ -1,0 +1,108 @@
+package com.redhat.red.build.finder.pnc.client;
+
+import java.util.List;
+
+import com.redhat.red.build.finder.pnc.client.model.Artifact;
+import com.redhat.red.build.finder.pnc.client.model.BuildConfiguration;
+import com.redhat.red.build.finder.pnc.client.model.BuildRecord;
+import com.redhat.red.build.finder.pnc.client.model.BuildRecordPushResult;
+import com.redhat.red.build.finder.pnc.client.model.ProductVersion;
+
+/**
+ * Interface to interact with PNC server
+ *
+ * @author Pedro Ruivo
+ */
+public interface PncClient {
+
+    /**
+     * Get a list of artifacts with matching md5. Returns empty list if no matching artifacts
+     *
+     * @param value md5 value
+     * @return list of artifacts
+     * @throws PncClientException in case something goes wrong
+     */
+    List<Artifact> getArtifactsByMd5(String value) throws PncClientException;
+
+    /**
+     * Get a list of artifacts with matching sha1. Returns empty list if no matching artifacts
+     *
+     * @param value sha1 value
+     * @return list of artifacts
+     * @throws PncClientException in case something goes wrong
+     */
+    List<Artifact> getArtifactsBySha1(String value) throws PncClientException;
+
+    /**
+     * Get a list of artifacts with matching sha256. Returns empty list if no matching artifacts
+     *
+     * @param value sha256 value
+     * @return list of artifacts
+     * @throws PncClientException in case something goes wrong
+     */
+    List<Artifact> getArtifactsBySha256(String value) throws PncClientException;
+
+    List<List<Artifact>> getArtifactsByMd5(List<String> values) throws PncClientException;
+
+    List<List<Artifact>> getArtifactsBySha1(List<String> values) throws PncClientException;
+
+    List<List<Artifact>> getArtifactsBySha256(List<String> values) throws PncClientException;
+
+    /**
+     * Get a list of artifacts with matching id. Returns empty list if no matching artifacts
+     *
+     * @param id buildrecord id
+     * @return list of artifacts
+     * @throws PncClientException in case something goes wrong
+     */
+    List<Artifact> getBuiltArtifactsById(int id) throws PncClientException;
+
+    List<List<Artifact>> getBuiltArtifactsById(List<Integer> ids) throws PncClientException;
+
+    List<BuildConfiguration> getBuildConfigurationsById(List<Integer> ids) throws PncClientException;
+
+    /**
+     * Get the BuildRecord object from the buildrecord id. Returns null if no buildrecord found
+     *
+     * @param id buildrecord id
+     * @return buildrecord DTO
+     * @throws PncClientException if something goes wrong
+     */
+    BuildRecord getBuildRecordById(int id) throws PncClientException;
+
+    List<BuildRecord> getBuildRecordsById(List<Integer> ids) throws PncClientException;
+
+    /**
+     * Get the BuildRecordPushResult object from the buildrecord id. Returns null if no buildrecord push result found
+     *
+     * @param id buildrecord id
+     * @return buildrecord push result DTO
+     * @throws PncClientException if something goes wrong
+     */
+    BuildRecordPushResult getBuildRecordPushResultById(int id) throws PncClientException;
+
+
+    /**
+     * Get the BuildConfiguration object from the buildconfiguration id. Returns null if no buildconfiguration found
+     *
+     * @param id buildconfiguration id
+     * @return buildconfiguration DTO
+     * @throws PncClientException if something goes wrong
+     */
+    BuildConfiguration getBuildConfigurationById(int id) throws PncClientException;
+
+    /**
+     * Get the ProductVersion object from the productversion id. Returns null if no productversion found
+     *
+     * @param id productversion id
+     * @return productversion DTO
+     * @throws PncClientException if something goes wrong
+     */
+    ProductVersion getProductVersionById(int id) throws PncClientException;
+
+    List<ProductVersion> getProductVersionsById(List<Integer> ids) throws PncClientException;
+
+    List<BuildRecordPushResult> getBuildRecordPushResultsById(List<Integer> ids) throws PncClientException;
+
+
+}

--- a/src/main/java/com/redhat/red/build/finder/pnc/client/PncClient14.java
+++ b/src/main/java/com/redhat/red/build/finder/pnc/client/PncClient14.java
@@ -15,290 +15,40 @@
  */
 package com.redhat.red.build.finder.pnc.client;
 
-import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
-import com.redhat.red.build.finder.BuildConfig;
-import org.apache.commons.collections4.ListUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.mashape.unirest.http.HttpResponse;
-import com.mashape.unirest.http.ObjectMapper;
 import com.mashape.unirest.http.Unirest;
 import com.mashape.unirest.http.exceptions.UnirestException;
-import com.redhat.red.build.finder.pnc.client.model.Artifact;
+import com.redhat.red.build.finder.BuildConfig;
 import com.redhat.red.build.finder.pnc.client.model.BuildConfiguration;
 import com.redhat.red.build.finder.pnc.client.model.BuildRecord;
-import com.redhat.red.build.finder.pnc.client.model.BuildRecordPushResult;
-import com.redhat.red.build.finder.pnc.client.model.PageParameterArtifact;
 import com.redhat.red.build.finder.pnc.client.model.PageParameterBuildConfiguration;
 import com.redhat.red.build.finder.pnc.client.model.PageParameterBuildRecord;
-import com.redhat.red.build.finder.pnc.client.model.PageParameterBuildRecordPushResult;
-import com.redhat.red.build.finder.pnc.client.model.PageParameterProductVersion;
-import com.redhat.red.build.finder.pnc.client.model.ProductVersion;
 
 /**
  * PncClient14 class for PNC 1.4.x APIs
- *
  */
-public class PncClient14 {
-    private static final Logger LOGGER = LoggerFactory.getLogger(PncClient14.class);
-
-    private BuildConfig config;
+public class PncClient14 extends BasePncClient implements PncClient {
 
     /**
      * Create a new PncClient14 object
      *
      * @param config the build configuration
      */
-    public PncClient14(BuildConfig config) {
-        this.config = config;
-        unirestSetup();
-        Unirest.setTimeouts(config.getPncConnectionTimeout(), config.getPncReadTimeout());
+    PncClient14(BuildConfig config) {
+        super(config);
     }
 
-    /**
-     * Setup Unirest to automatically convert JSON into DTO
-     */
-    private static void unirestSetup() {
-        Unirest.setObjectMapper(new ObjectMapper() {
-            private com.fasterxml.jackson.databind.ObjectMapper jacksonObjectMapper = new com.fasterxml.jackson.databind.ObjectMapper().registerModule(new JavaTimeModule());
-
-            public <T> T readValue(String value, Class<T> valueType) {
-                try {
-                    return jacksonObjectMapper.readValue(value, valueType);
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-
-            public String writeValue(Object value) {
-                try {
-                    return jacksonObjectMapper.writeValueAsString(value);
-                } catch (JsonProcessingException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-        });
-    }
-
-    /**
-     * Get a list of artifacts with matching md5. Returns empty list if no matching artifacts
-     *
-     * @param value md5 value
-     * @return list of artifacts
-     *
-     * @throws PncClientException in case something goes wrong
-     */
-    public List<Artifact> getArtifactsByMd5(String value) throws PncClientException {
-        return getArtifacts("md5", value);
-    }
-
-    /**
-     * Get a list of artifacts with matching sha1. Returns empty list if no matching artifacts
-     *
-     * @param value sha1 value
-     * @return list of artifacts
-     *
-     * @throws PncClientException in case something goes wrong
-     */
-    public List<Artifact> getArtifactsBySha1(String value) throws PncClientException {
-        return getArtifacts("sha1", value);
-    }
-
-    /**
-     * Get a list of artifacts with matching sha256. Returns empty list if no matching artifacts
-     *
-     * @param value sha256 value
-     * @return list of artifacts
-     *
-     * @throws PncClientException in case something goes wrong
-     */
-    public List<Artifact> getArtifactsBySha256(String value) throws PncClientException {
-        return getArtifacts("sha256", value);
-    }
-
-    private String getArtifactsUrl(String key, String value) {
-        return config.getPncURL() + "/pnc-rest/rest/artifacts" + "?" + key + "=" + value;
-    }
-
-    private List<Artifact> getArtifacts(String key, String value) throws PncClientException {
-        try {
-            String urlRequest = getArtifactsUrl(key, value);
-            HttpResponse<PageParameterArtifact> artifacts = Unirest.get(urlRequest).asObject(PageParameterArtifact.class);
-            PageParameterArtifact artifactData = artifacts.getBody();
-
-            if (artifactData == null) {
-                return Collections.emptyList();
-            } else {
-                return artifactData.getContent();
-            }
-        } catch (UnirestException e) {
-            throw new PncClientException(e);
-        }
-
-    }
-
-    private List<List<Artifact>> getArtifactsSplit(List<String> values, String key) throws PncClientException {
-        int size = values.size();
-        int partitionSize = config.getPncPartitionSize();
-        List<List<Artifact>> result = new ArrayList<>(size);
-        List<List<String>> splitValues = ListUtils.partition(values, partitionSize);
-
-        for (List<String> splitValue : splitValues) {
-            int keysSize = splitValue.size();
-            List<String> keys = Collections.nCopies(keysSize, key);
-            List<List<Artifact>> artifacts = getArtifacts(keys, splitValue);
-            result.addAll(artifacts);
-        }
-
-        return result;
-    }
-
-    public List<List<Artifact>> getArtifactsByMd5(List<String> values) throws PncClientException {
-        return getArtifactsSplit(values, "md5");
-    }
-
-    public List<List<Artifact>> getArtifactsBySha1(List<String> values) throws PncClientException {
-        return getArtifactsSplit(values, "sha1");
-    }
-
-    public List<List<Artifact>> getArtifactsBySha256(List<String> values) throws PncClientException {
-        return getArtifactsSplit(values, "sha256");
-    }
-
-    private List<List<Artifact>> getArtifacts(List<String> keys, List<String> values) throws PncClientException {
-        if (keys.size() != values.size()) {
-            throw new PncClientException("Mismatched keys and values sizes");
-        }
-
-        List<List<Artifact>> artifactsList = new ArrayList<>(values.size());
-        List<Future<HttpResponse<PageParameterArtifact>>> futures = new ArrayList<>(values.size());
-        int size = keys.size();
-
-        for (int i = 0; i < size; i++) {
-            String key = keys.get(i);
-            String value = values.get(i);
-            String urlRequest = getArtifactsUrl(key, value);
-            LOGGER.debug("key={}, value={}, urlRequest={}", key, value, urlRequest);
-            Future<HttpResponse<PageParameterArtifact>> artifacts = Unirest.get(urlRequest).asObjectAsync(PageParameterArtifact.class);
-            futures.add(artifacts);
-        }
-
-        for (Future<HttpResponse<PageParameterArtifact>> artifact : futures) {
-            try {
-                HttpResponse<PageParameterArtifact> artifacts = artifact.get();
-                PageParameterArtifact artifactData = artifacts.getBody();
-
-                if (artifactData == null) {
-                    artifactsList.add(Collections.emptyList());
-                } else {
-                    artifactsList.add(artifactData.getContent());
-                }
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            } catch (ExecutionException e) {
-                throw new PncClientException(e);
-            }
-        }
-
-        return artifactsList;
-    }
-
-    private String getBuiltArtifactsByIdUrl(int id) {
-        return config.getPncURL() + "/pnc-rest/rest/build-records/" + id + "/built-artifacts";
-    }
-
-    /**
-     * Get a list of artifacts with matching id. Returns empty list if no matching artifacts
-     *
-     * @param id buildrecord id
-     * @return list of artifacts
-     *
-     * @throws PncClientException in case something goes wrong
-     */
-    public List<Artifact> getBuiltArtifactsById(int id) throws PncClientException {
-        try {
-            String urlRequest = getBuiltArtifactsByIdUrl(id);
-            HttpResponse<PageParameterArtifact> artifacts = Unirest.get(urlRequest).asObject(PageParameterArtifact.class);
-            PageParameterArtifact artifactData = artifacts.getBody();
-
-            if (artifactData == null) {
-                return Collections.emptyList();
-            } else {
-                return artifactData.getContent();
-            }
-
-        } catch (UnirestException e) {
-            throw new PncClientException(e);
-        }
-    }
-
-    public List<List<Artifact>> getBuiltArtifactsById(List<Integer> ids) throws PncClientException {
-        List<List<Artifact>> artifactList = new ArrayList<>(ids.size());
-        List<Future<HttpResponse<PageParameterArtifact>>> futures = new ArrayList<>(ids.size());
-
-        for (Integer id : ids) {
-            String urlRequest = getBuiltArtifactsByIdUrl(id);
-            Future<HttpResponse<PageParameterArtifact>> artifactFuture = Unirest.get(urlRequest).asObjectAsync(PageParameterArtifact.class);
-            futures.add(artifactFuture);
-        }
-
-        for (Future<HttpResponse<PageParameterArtifact>> artifact : futures) {
-            try {
-                HttpResponse<PageParameterArtifact> artifacts = artifact.get();
-                PageParameterArtifact artifactData = artifacts.getBody();
-
-                if (artifactData == null) {
-                    artifactList.add(Collections.emptyList());
-                } else {
-                    artifactList.add(artifactData.getContent());
-                }
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            } catch (ExecutionException e) {
-                throw new PncClientException(e);
-            }
-        }
-
-        return artifactList;
-    }
-
-    private String getBuildRecordByIdUrl(int id) {
-        return config.getPncURL() + "/pnc-rest/rest/build-records/" + id;
-    }
-
-    private String getBuildRecordPushResultByIdUrl(int id) {
-        return config.getPncURL() + "/pnc-rest/rest/build-record-push/status/" + id;
-    }
-
-    private String getBuildConfigurationByIdUrl(int id) {
-        return config.getPncURL() + "/pnc-rest/rest/build-configurations/" + id;
-    }
-
-    private String getProductVersionByIdUrl(int id) {
-        return config.getPncURL() + "/pnc-rest/rest/product-versions/" + id;
-    }
-
-    /**
-     * Get the BuildRecord object from the buildrecord id. Returns null if no buildrecord found
-     *
-     * @param id buildrecord id
-     * @return buildrecord DTO
-     *
-     * @throws PncClientException if something goes wrong
-     */
-    public BuildRecord getBuildRecordById(int id) throws PncClientException {
+    @Override
+    public final BuildRecord getBuildRecordById(int id) throws PncClientException {
         try {
             String urlRequest = getBuildRecordByIdUrl(id);
-            HttpResponse<PageParameterBuildRecord> buildRecords = Unirest.get(urlRequest).asObject(PageParameterBuildRecord.class);
+            HttpResponse<PageParameterBuildRecord> buildRecords = Unirest.get(urlRequest)
+                                                                         .asObject(PageParameterBuildRecord.class);
             PageParameterBuildRecord buildRecordData = buildRecords.getBody();
 
             if (buildRecordData == null) {
@@ -311,12 +61,14 @@ public class PncClient14 {
         }
     }
 
-    public List<BuildRecord> getBuildRecordsById(List<Integer> ids) throws PncClientException {
+    @Override
+    public final List<BuildRecord> getBuildRecordsById(List<Integer> ids) throws PncClientException {
         List<Future<HttpResponse<PageParameterBuildRecord>>> futures = new ArrayList<>(ids.size());
 
-        for (Integer id: ids) {
+        for (Integer id : ids) {
             String urlRequest = getBuildRecordByIdUrl(id);
-            Future<HttpResponse<PageParameterBuildRecord>> buildRecordFuture = Unirest.get(urlRequest).asObjectAsync(PageParameterBuildRecord.class);
+            Future<HttpResponse<PageParameterBuildRecord>> buildRecordFuture = Unirest.get(urlRequest).asObjectAsync(
+                PageParameterBuildRecord.class);
             futures.add(buildRecordFuture);
         }
 
@@ -343,92 +95,27 @@ public class PncClient14 {
         return buildRecordList;
     }
 
-    /**
-     * Get the BuildRecordPushResult object from the buildrecord id. Returns null if no buildrecord push result found
-     *
-     * @param id buildrecord id
-     * @return buildrecord push result DTO
-     *
-     * @throws PncClientException if something goes wrong
-     */
-    public BuildRecordPushResult getBuildRecordPushResultById(int id) throws PncClientException {
-        try {
-            String urlRequest = getBuildRecordPushResultByIdUrl(id);
-            HttpResponse<PageParameterBuildRecordPushResult> buildRecordPushResults = Unirest.get(urlRequest).asObject(PageParameterBuildRecordPushResult.class);
-            PageParameterBuildRecordPushResult buildRecordPushResultData = buildRecordPushResults.getBody();
-
-            if (buildRecordPushResultData == null) {
-                return null;
-            } else {
-                return buildRecordPushResultData.getContent();
-            }
-        } catch (UnirestException e) {
-            throw new PncClientException(e);
-        }
-    }
-
-    public List<BuildRecordPushResult> getBuildRecordPushResultsById(List<Integer> ids) throws PncClientException {
-        List<Future<HttpResponse<PageParameterBuildRecordPushResult>>> futures = new ArrayList<>(ids.size());
-
-        for (Integer id: ids) {
-            String urlRequest = getBuildRecordPushResultByIdUrl(id);
-            Future<HttpResponse<PageParameterBuildRecordPushResult>> buildRecordFuture = Unirest.get(urlRequest).asObjectAsync(PageParameterBuildRecordPushResult.class);
-            futures.add(buildRecordFuture);
-        }
-
-        List<BuildRecordPushResult> buildRecordPushResultList = new ArrayList<>(ids.size());
-
-        for (Future<HttpResponse<PageParameterBuildRecordPushResult>> future : futures) {
-
-            try {
-                HttpResponse<PageParameterBuildRecordPushResult> buildRecordPushResultData = future.get();
-                PageParameterBuildRecordPushResult buildRecordData = buildRecordPushResultData.getBody();
-
-                if (buildRecordData == null) {
-                    buildRecordPushResultList.add(null);
-                } else {
-                    buildRecordPushResultList.add(buildRecordData.getContent());
-                }
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            } catch (ExecutionException e) {
-                throw new PncClientException(e);
-            }
-        }
-
-        return buildRecordPushResultList;
-    }
-
-    /**
-     * Get the BuildConfiguration object from the buildconfiguration id. Returns null if no buildconfiguration found
-     *
-     * @param id buildconfiguration id
-     * @return buildconfiguration DTO
-     *
-     * @throws PncClientException if something goes wrong
-     */
-    public BuildConfiguration getBuildConfigurationById(int id) throws PncClientException {
+    @Override
+    public final BuildConfiguration getBuildConfigurationById(int id) throws PncClientException {
         try {
             String urlRequest = getBuildConfigurationByIdUrl(id);
-            HttpResponse<PageParameterBuildConfiguration> buildConfigurations = Unirest.get(urlRequest).asObject(PageParameterBuildConfiguration.class);
-            PageParameterBuildConfiguration buildConfigurationData = buildConfigurations.getBody();
-
-            if (buildConfigurationData == null) {
-                return null;
-            } else {
-                return buildConfigurationData.getContent();
-            }
+            HttpResponse<BuildConfiguration> buildConfigurations = Unirest.get(urlRequest).asObject(
+                BuildConfiguration.class);
+            return buildConfigurations.getBody();
         } catch (UnirestException e) {
             throw new PncClientException(e);
         }
     }
 
-    public List<BuildConfiguration> getBuildConfigurationsById(List<Integer> ids) throws PncClientException {
+    @Override
+    public final List<BuildConfiguration> getBuildConfigurationsById(List<Integer> ids) throws PncClientException {
         List<Future<HttpResponse<PageParameterBuildConfiguration>>> futures = new ArrayList<>(ids.size());
 
-        for (Integer id: ids) {
+        for (Integer id : ids) {
             String urlRequest = getBuildConfigurationByIdUrl(id);
-            Future<HttpResponse<PageParameterBuildConfiguration>> buildConfigurationFuture = Unirest.get(urlRequest).asObjectAsync(PageParameterBuildConfiguration.class);
+            Future<HttpResponse<PageParameterBuildConfiguration>> buildConfigurationFuture = Unirest.get(urlRequest)
+                                                                                                    .asObjectAsync(
+                                                                                                        PageParameterBuildConfiguration.class);
             futures.add(buildConfigurationFuture);
         }
 
@@ -455,59 +142,30 @@ public class PncClient14 {
         return buildConfigurationList;
     }
 
-    /**
-     * Get the ProductVersion object from the productversion id. Returns null if no productversion found
-     *
-     * @param id productversion id
-     * @return productversion DTO
-     *
-     * @throws PncClientException if something goes wrong
-     */
-    public ProductVersion getProductVersionById(int id) throws PncClientException {
-        try {
-            String urlRequest = getProductVersionByIdUrl(id);
-            HttpResponse<PageParameterProductVersion> buildConfigurations = Unirest.get(urlRequest).asObject(PageParameterProductVersion.class);
-            PageParameterProductVersion buildConfigurationData = buildConfigurations.getBody();
-
-            if (buildConfigurationData == null) {
-                return null;
-            } else {
-                return buildConfigurationData.getContent();
-            }
-        } catch (UnirestException e) {
-            throw new PncClientException(e);
-        }
+    private String getBuildRecordByIdUrl(int id) {
+        return getConfig().getPncURL() + "/pnc-rest/rest/build-records/" + id;
     }
 
-    public List<ProductVersion> getProductVersionsById(List<Integer> ids) throws PncClientException {
-        List<Future<HttpResponse<PageParameterProductVersion>>> futures = new ArrayList<>(ids.size());
+    @Override
+    String getBuiltArtifactsByIdUrl(int id) {
+        return getConfig().getPncURL() + "/pnc-rest/rest/build-records/" + id + "/built-artifacts";
+    }
 
-        for (Integer id: ids) {
-            String urlRequest = getProductVersionByIdUrl(id);
-            Future<HttpResponse<PageParameterProductVersion>> buildConfigurationFuture = Unirest.get(urlRequest).asObjectAsync(PageParameterProductVersion.class);
-            futures.add(buildConfigurationFuture);
-        }
+    @Override
+    String getBuildRecordPushResultByIdUrl(int id) {
+        return getConfig().getPncURL() + "/pnc-rest/rest/build-record-push/status/" + id;
+    }
 
-        List<ProductVersion> buildConfigurationList = new ArrayList<>(ids.size());
+    String getProductVersionByIdUrl(int id) {
+        return getConfig().getPncURL() + "/pnc-rest/rest/product-versions/" + id;
+    }
 
-        for (Future<HttpResponse<PageParameterProductVersion>> future : futures) {
+    private String getBuildConfigurationByIdUrl(int id) {
+        return getConfig().getPncURL() + "/pnc-rest/rest/build-configurations/" + id;
+    }
 
-            try {
-                HttpResponse<PageParameterProductVersion> buildConfiguration = future.get();
-                PageParameterProductVersion buildConfigurationData = buildConfiguration.getBody();
-
-                if (buildConfigurationData == null) {
-                    buildConfigurationList.add(null);
-                } else {
-                    buildConfigurationList.add(buildConfigurationData.getContent());
-                }
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            } catch (ExecutionException e) {
-                throw new PncClientException(e);
-            }
-        }
-
-        return buildConfigurationList;
+    @Override
+    String getArtifactsUrl(String key, String value) {
+        return getConfig().getPncURL() + "/pnc-rest/rest/artifacts" + "?" + key + "=" + value;
     }
 }

--- a/src/main/java/com/redhat/red/build/finder/pnc/client/PncClient20.java
+++ b/src/main/java/com/redhat/red/build/finder/pnc/client/PncClient20.java
@@ -1,0 +1,124 @@
+package com.redhat.red.build.finder.pnc.client;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.function.Function;
+
+import com.mashape.unirest.http.HttpResponse;
+import com.mashape.unirest.http.Unirest;
+import com.redhat.red.build.finder.BuildConfig;
+import com.redhat.red.build.finder.pnc.client.model.BuildConfiguration;
+import com.redhat.red.build.finder.pnc.client.model.BuildRecord;
+
+/**
+ * {@link PncClient} implementation that knows how to communicate with PNC version 2.
+ *
+ * @author Pedro Ruivo
+ */
+public class PncClient20 extends BasePncClient implements PncClient {
+
+    private static final String BUILD_ARTIFACTS = "%s/pnc-rest/v2/builds/%s/artifacts/built";
+    private static final String BUILD_RECORD = "%s/pnc-rest/v2/build-records/%s";
+    private static final String BREW_PUSH_RESULT = "%s/pnc-rest/v2/builds/%s/brew-push";
+    private static final String PRODUCT_VERSIONS = "%s/pnc-rest/v2/products/%s/versions";
+    private static final String BUILD_CONFIG = "%s/pnc-rest/v2/build-configs/%s";
+    private static final String ARTIFACTS_BY_CHECKSUM = "%s/pnc-rest/v2/artifacts?%s=%s";
+
+    /**
+     * Create a new PncClient20 object
+     *
+     * @param config the build configuration
+     */
+    PncClient20(BuildConfig config) {
+        super(config);
+    }
+
+    @Override
+    public final List<BuildConfiguration> getBuildConfigurationsById(List<Integer> ids) throws PncClientException {
+        return getMultiple(ids, this::getBuildConfigurationByIdAsync);
+    }
+
+    @Override
+    public final BuildRecord getBuildRecordById(int id) throws PncClientException {
+        return getSingle(id, this::getBuildRecordByIdAsync);
+    }
+
+    @Override
+    public final List<BuildRecord> getBuildRecordsById(List<Integer> ids) throws PncClientException {
+        return getMultiple(ids, this::getBuildRecordByIdAsync);
+    }
+
+    @Override
+    public final BuildConfiguration getBuildConfigurationById(int id) throws PncClientException {
+        return getSingle(id, this::getBuildConfigurationByIdAsync);
+    }
+
+    private static <K, V> V getSingle(K input, Function<K, Future<HttpResponse<V>>> mapper)
+        throws PncClientException {
+        try {
+            return mapper.apply(input).get().getBody();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (ExecutionException e) {
+            throw new PncClientException(e.getCause());
+        }
+        return null;
+    }
+
+    private Future<HttpResponse<BuildRecord>> getBuildRecordByIdAsync(int id) {
+        String urlRequest = getBuildRecordByIdUrl(id);
+        return Unirest.get(urlRequest).asObjectAsync(BuildRecord.class);
+    }
+
+    private String getBuildRecordByIdUrl(int id) {
+        return String.format(BUILD_RECORD, getConfig().getPncURL(), id);
+    }
+
+    private static <K, V> List<V> getMultiple(List<K> inputs, Function<K, Future<HttpResponse<V>>> mapper)
+        throws PncClientException {
+        Iterator<Future<HttpResponse<V>>> iterator = inputs.stream().map(mapper).iterator();
+        List<V> outputs = new ArrayList<>(inputs.size());
+        while (iterator.hasNext()) {
+            try {
+                outputs.add(iterator.next().get().getBody());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } catch (ExecutionException e) {
+                throw new PncClientException(e.getCause());
+            }
+        }
+        return outputs;
+    }
+
+    private Future<HttpResponse<BuildConfiguration>> getBuildConfigurationByIdAsync(int id) {
+        String urlRequest = getBuildConfigurationByIdUrl(id);
+        return Unirest.get(urlRequest).asObjectAsync(BuildConfiguration.class);
+    }
+
+    private String getBuildConfigurationByIdUrl(int id) {
+        return String.format(BUILD_CONFIG, getConfig().getPncURL(), id);
+    }
+
+    @Override
+    String getBuiltArtifactsByIdUrl(int id) {
+        return String.format(BUILD_ARTIFACTS, getConfig().getPncURL(), id);
+    }
+
+    @Override
+    String getBuildRecordPushResultByIdUrl(int id) {
+        return String.format(BREW_PUSH_RESULT, getConfig().getPncURL(), id);
+    }
+
+    @Override
+    String getProductVersionByIdUrl(int id) {
+        return String.format(PRODUCT_VERSIONS, getConfig().getPncURL(), id);
+    }
+
+    @Override
+    String getArtifactsUrl(String checksumMethod, String value) {
+        return String.format(ARTIFACTS_BY_CHECKSUM, getConfig().getPncURL(), checksumMethod, value);
+    }
+}

--- a/src/main/java/com/redhat/red/build/finder/pnc/client/PncClientFactory.java
+++ b/src/main/java/com/redhat/red/build/finder/pnc/client/PncClientFactory.java
@@ -1,0 +1,33 @@
+package com.redhat.red.build.finder.pnc.client;
+
+import com.redhat.red.build.finder.BuildConfig;
+import com.redhat.red.build.finder.BuildSystem;
+
+/**
+ * {@link PncClient} factory which creates the correct implementation based on the {@link BuildConfig}.
+ *
+ * @author Pedro Ruivo
+ */
+public final class PncClientFactory {
+
+    private PncClientFactory() {
+    }
+
+    public static PncClient create(BuildConfig config) {
+        if (config.getPncURL() == null) {
+            return null;
+        }
+        //TODO it would be nice to have REST path to query te version used.
+        if (config.getBuildSystems().contains(BuildSystem.pnc2)) {
+            //PNC 2
+            return new PncClient20(config);
+        } else if (config.getBuildSystems().contains(BuildSystem.pnc)) {
+            //PNC 1
+            return new PncClient14(config);
+        } else {
+            //no PNC callS
+            return null;
+        }
+    }
+
+}

--- a/src/main/java/com/redhat/red/build/finder/pnc/client/model/Artifact.java
+++ b/src/main/java/com/redhat/red/build/finder/pnc/client/model/Artifact.java
@@ -17,6 +17,7 @@ package com.redhat.red.build.finder.pnc.client.model;
 
 import java.io.Serializable;
 import java.time.Instant;
+import java.util.Collections;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -60,6 +61,8 @@ public class Artifact implements Serializable {
      * Public url to the artifact using public network domain
      */
     private String publicUrl;
+
+    private BuildRecord build;
 
     public Integer getId() {
         return id;
@@ -126,7 +129,9 @@ public class Artifact implements Serializable {
     }
 
     public List<Integer> getBuildRecordIds() {
-        return buildRecordIds;
+        return buildRecordIds == null
+               ? (build == null ? Collections.emptyList() : Collections.singletonList(build.getId())) : //PNC2
+               buildRecordIds;
     }
 
     public void setBuildRecordIds(List<Integer> buildRecordIds) {
@@ -181,6 +186,14 @@ public class Artifact implements Serializable {
         this.publicUrl = publicUrl;
     }
 
+    public BuildRecord getBuild() {
+        return build;
+    }
+
+    public void setBuild(BuildRecord build) {
+        this.build = build;
+    }
+
     public enum Quality {
         NEW,
         VERIFIED,
@@ -197,6 +210,6 @@ public class Artifact implements Serializable {
             + md5 + ", sha1=" + sha1 + ", sha256=" + sha256 + ", filename=" + filename + ", deployPath="
             + deployPath + ", buildRecordIds=" + buildRecordIds + ", dependantBuildRecordIds="
             + dependantBuildRecordIds + ", importDate=" + importDate + ", originUrl=" + originUrl + ", size=" + size
-            + ", deployUrl=" + deployUrl + ", publicUrl=" + publicUrl + "]";
+            + ", deployUrl=" + deployUrl + ", publicUrl=" + publicUrl + ", build=" + build + "]";
     }
 }

--- a/src/main/java/com/redhat/red/build/finder/pnc/client/model/BuildConfigurationRevision.java
+++ b/src/main/java/com/redhat/red/build/finder/pnc/client/model/BuildConfigurationRevision.java
@@ -1,0 +1,106 @@
+package com.redhat.red.build.finder.pnc.client.model;
+
+import java.io.Serializable;
+import java.time.Instant;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Build configuration revision. Available in PNC2
+ *
+ * @author Pedro Ruivo
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BuildConfigurationRevision implements Serializable {
+
+    private static final long serialVersionUID = -5920335553408051883L;
+    private Integer id;
+    private Integer rev;
+    private String name;
+    private String buildScript;
+    private String scmRevision;
+    private Instant creationTime;
+    private Instant modificationTime;
+    private String buildType;
+    private String defaultAlignmentParams;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public Integer getRev() {
+        return rev;
+    }
+
+    public void setRev(Integer rev) {
+        this.rev = rev;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getBuildScript() {
+        return buildScript;
+    }
+
+    public void setBuildScript(String buildScript) {
+        this.buildScript = buildScript;
+    }
+
+    public String getScmRevision() {
+        return scmRevision;
+    }
+
+    public void setScmRevision(String scmRevision) {
+        this.scmRevision = scmRevision;
+    }
+
+    public Instant getCreationTime() {
+        return creationTime;
+    }
+
+    public void setCreationTime(Instant creationTime) {
+        this.creationTime = creationTime;
+    }
+
+    public Instant getModificationTime() {
+        return modificationTime;
+    }
+
+    public void setModificationTime(Instant modificationTime) {
+        this.modificationTime = modificationTime;
+    }
+
+    public String getBuildType() {
+        return buildType;
+    }
+
+    public void setBuildType(String buildType) {
+        this.buildType = buildType;
+    }
+
+    public String getDefaultAlignmentParams() {
+        return defaultAlignmentParams;
+    }
+
+    public void setDefaultAlignmentParams(String defaultAlignmentParams) {
+        this.defaultAlignmentParams = defaultAlignmentParams;
+    }
+
+    @Override
+    public String toString() {
+        return "BuildConfigurationRevision [id=" + id + ", rev=" + rev + ", name=" + name + ", buildScript="
+            + buildScript + ", scmRevision=" + scmRevision + ", creationTime=" + creationTime + ", modificationTime="
+            + modificationTime + ", buildType=" + buildType + ", defaultAlignmentParams=" + defaultAlignmentParams
+            + "]";
+    }
+}

--- a/src/main/java/com/redhat/red/build/finder/pnc/client/model/BuildRecord.java
+++ b/src/main/java/com/redhat/red/build/finder/pnc/client/model/BuildRecord.java
@@ -78,6 +78,10 @@ public class BuildRecord implements Serializable {
 
     private List<Integer> dependencyBuildRecordIds;
 
+    private BuildConfigurationRevision buildConfigRevision;
+
+    private Project project;
+
     public Integer getId() {
         return id;
     }
@@ -111,7 +115,9 @@ public class BuildRecord implements Serializable {
     }
 
     public Integer getBuildConfigurationId() {
-        return buildConfigurationId;
+        return buildConfigurationId == null
+               ? buildConfigRevision.getId() : //PNC2
+               buildConfigurationId;
     }
 
     public void setBuildConfigurationId(Integer buildConfigurationId) {
@@ -135,7 +141,9 @@ public class BuildRecord implements Serializable {
     }
 
     public Integer getProjectId() {
-        return projectId;
+        return projectId == null
+               ? project.getId() : //PNC2
+               projectId;
     }
 
     public void setProjectId(Integer projectId) {
@@ -143,7 +151,9 @@ public class BuildRecord implements Serializable {
     }
 
     public String getProjectName() {
-        return projectName;
+        return projectName == null
+               ? project.getName() : //PNC2
+               projectName;
     }
 
     public void setProjectName(String projectName) {
@@ -268,6 +278,23 @@ public class BuildRecord implements Serializable {
 
     public void setDependencyBuildRecordIds(List<Integer> dependencyBuildRecordIds) {
         this.dependencyBuildRecordIds = dependencyBuildRecordIds;
+    }
+
+    public BuildConfigurationRevision getBuildConfigRevision() {
+        return buildConfigRevision;
+    }
+
+    public void setBuildConfigRevision(
+        BuildConfigurationRevision buildConfigRevision) {
+        this.buildConfigRevision = buildConfigRevision;
+    }
+
+    public Project getProject() {
+        return project;
+    }
+
+    public void setProject(Project project) {
+        this.project = project;
     }
 
     @Override

--- a/src/test/java/com/redhat/red/build/finder/it/AbstractKojiIT.java
+++ b/src/test/java/com/redhat/red/build/finder/it/AbstractKojiIT.java
@@ -35,7 +35,8 @@ import com.codahale.metrics.Slf4jReporter;
 import com.redhat.red.build.finder.BuildConfig;
 import com.redhat.red.build.finder.ConfigDefaults;
 import com.redhat.red.build.finder.KojiClientSession;
-import com.redhat.red.build.finder.pnc.client.PncClient14;
+import com.redhat.red.build.finder.pnc.client.PncClient;
+import com.redhat.red.build.finder.pnc.client.PncClientFactory;
 import com.redhat.red.build.koji.KojiClientException;
 import com.redhat.red.build.koji.config.SimpleKojiConfig;
 import com.redhat.red.build.koji.config.SimpleKojiConfigBuilder;
@@ -51,7 +52,7 @@ public abstract class AbstractKojiIT {
 
     private BuildConfig config;
 
-    private PncClient14 pncclient;
+    private PncClient pncclient;
 
     protected static final int MAX_CONNECTIONS = 20;
 
@@ -81,7 +82,7 @@ public abstract class AbstractKojiIT {
 
         final SimpleKojiConfig kojiConfig = new SimpleKojiConfigBuilder().withKojiURL(kojiHubURL.toExternalForm()).withMaxConnections(MAX_CONNECTIONS).build();
         this.session = new KojiClientSession(kojiConfig, new MemoryPasswordManager(), Executors.newFixedThreadPool(DEFAULT_THREAD_COUNT), REGISTRY);
-        this.pncclient = new PncClient14(config);
+        this.pncclient = PncClientFactory.create(config);
         this.reporter = Slf4jReporter.forRegistry(REGISTRY).outputTo(LOGGER).convertRatesTo(TimeUnit.SECONDS).convertDurationsTo(TimeUnit.SECONDS).build();
 
         reporter.start(600, TimeUnit.SECONDS);
@@ -95,7 +96,7 @@ public abstract class AbstractKojiIT {
         return config;
     }
 
-    public PncClient14 getPncClient() {
+    public PncClient getPncClient() {
         return pncclient;
     }
 

--- a/src/test/java/com/redhat/red/build/finder/it/AbstractPncClientIT.java
+++ b/src/test/java/com/redhat/red/build/finder/it/AbstractPncClientIT.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.redhat.red.build.finder.it;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.redhat.red.build.finder.BuildConfig;
+import com.redhat.red.build.finder.pnc.client.PncClient;
+import com.redhat.red.build.finder.pnc.client.PncClientException;
+import com.redhat.red.build.finder.pnc.client.model.Artifact;
+import com.redhat.red.build.finder.pnc.client.model.BuildConfiguration;
+import com.redhat.red.build.finder.pnc.client.model.BuildRecord;
+
+public abstract class AbstractPncClientIT {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractPncClientIT.class);
+    private static final String PROPERTY = "com.redhat.red.build.finder.it.pnc.url";
+    private static final String PNC_URL = System.getProperty(PROPERTY);
+    private static final Long CONNECTION_TIMEOUT = 300000L;
+    private static final Long READ_TIMEOUT = 900000L;
+
+    @Before
+    public void verify() {
+        assertNotNull("You must set -Dcom.redhat.red.build.finder.it.pnc.url=<pnc server>", PNC_URL);
+    }
+
+    @Test
+    public void testDefaultPncClient() throws PncClientException, MalformedURLException {
+        BuildConfig config = new BuildConfig();
+        URL pncUrl = new URL(PNC_URL);
+        config.setPncURL(pncUrl);
+        PncClient client = createPncClient(config);
+        getAnArtifactAndBuildRecord(client);
+    }
+
+    @Test
+    public void testPncClientWithTimeouts() throws PncClientException, MalformedURLException {
+        BuildConfig config = new BuildConfig();
+        URL pncUrl = new URL(PNC_URL);
+        config.setPncURL(pncUrl);
+        config.setPncConnectionTimeout(CONNECTION_TIMEOUT);
+        config.setPncReadTimeout(READ_TIMEOUT);
+        PncClient client = createPncClient(config);
+        getAnArtifactAndBuildRecord(client);
+    }
+
+    @Test
+    public void testReturnEmptyListIfNoMatchingSha() throws PncClientException, MalformedURLException {
+        BuildConfig config = new BuildConfig();
+        URL pncUrl = new URL(PNC_URL);
+        config.setPncURL(pncUrl);
+        PncClient client = createPncClient(config);
+        List<Artifact> artifactsMd5 = client.getArtifactsByMd5("do-not-exist");
+        assertNotNull(artifactsMd5);
+        assertTrue(artifactsMd5.isEmpty());
+
+        List<Artifact> artifactsSha1 = client.getArtifactsBySha1("do-not-exist");
+        assertNotNull(artifactsSha1);
+        assertTrue(artifactsSha1.isEmpty());
+
+        List<Artifact> artifactsSha256 = client.getArtifactsBySha256("do-not-exist");
+        assertNotNull(artifactsSha256);
+        assertTrue(artifactsSha256.isEmpty());
+    }
+
+    @Test
+    public void testReturnNullIfNoMatchingBuildRecord() throws PncClientException, MalformedURLException {
+        BuildConfig config = new BuildConfig();
+        URL pncUrl = new URL(PNC_URL);
+        config.setPncURL(pncUrl);
+        PncClient client = createPncClient(config);
+        BuildRecord record = client.getBuildRecordById(-1);
+        assertNull(record);
+    }
+
+    private void getAnArtifactAndBuildRecord(PncClient client) throws PncClientException {
+        final String md5 = "6a1a161bb7a696df419d149df034d189";
+        final String sha1 = "8a50c8f39257bfe488f578bf52f70e641023b020";
+        final String sha256 = "840b8f9f9a516fcc7e74da710480c6c8f5700ce9bdfa52a5cb752bfe9c54fe92";
+        final int id = 15821;
+
+        List<Artifact> artifactsMd5 = client.getArtifactsByMd5(md5);
+        List<Artifact> artifactsSha1 = client.getArtifactsBySha1(sha1);
+        List<Artifact> artifactsSha256 = client.getArtifactsBySha256(sha256);
+
+        assertEquals(1, artifactsMd5.size());
+        assertEquals(1, artifactsSha1.size());
+        assertEquals(1, artifactsSha256.size());
+
+        Artifact artifactMd5 = artifactsMd5.get(0);
+        Artifact artifactSha1 = artifactsSha1.get(0);
+        Artifact artifactSha256 = artifactsSha256.get(0);
+
+        assertEquals(md5, artifactMd5.getMd5());
+        assertEquals(sha1, artifactSha1.getSha1());
+        assertEquals(sha256, artifactSha256.getSha256());
+
+        assertEquals(artifactMd5.getId(), artifactSha1.getId());
+        assertEquals(artifactSha1.getId(), artifactSha256.getId());
+
+        LOGGER.debug("Artifact name: {}", artifactMd5.getFilename());
+
+        List<Integer> buildRecordIds = artifactMd5.getBuildRecordIds();
+
+        Collections.sort(buildRecordIds);
+
+        assertTrue(buildRecordIds.contains(id));
+
+        BuildRecord record = client.getBuildRecordById(id);
+        BuildConfiguration configuration = client.getBuildConfigurationById(record.getBuildConfigurationId());
+
+        LOGGER.debug("Build configuration: {}", configuration.toString());
+
+        assertEquals("hibernate-hibernate-core", record.getProjectName());
+
+        assertEquals("hibernate-hibernate-core", configuration.getName());
+
+        List<Artifact> artifacts = client.getBuiltArtifactsById(record.getProjectId());
+
+        assertFalse(artifacts.isEmpty());
+    }
+
+    abstract PncClient createPncClient(BuildConfig config);
+}

--- a/src/test/java/com/redhat/red/build/finder/it/PncClient20IT.java
+++ b/src/test/java/com/redhat/red/build/finder/it/PncClient20IT.java
@@ -22,16 +22,16 @@ import java.util.Collections;
 import com.redhat.red.build.finder.BuildConfig;
 import com.redhat.red.build.finder.BuildSystem;
 import com.redhat.red.build.finder.pnc.client.PncClient;
-import com.redhat.red.build.finder.pnc.client.PncClient14;
+import com.redhat.red.build.finder.pnc.client.PncClient20;
 import com.redhat.red.build.finder.pnc.client.PncClientFactory;
 
-public class PncClient14IT extends AbstractPncClientIT {
+public class PncClient20IT extends AbstractPncClientIT {
 
     @Override
     PncClient createPncClient(BuildConfig config) {
-        config.setBuildSystems(Collections.singletonList(BuildSystem.pnc));
+        config.setBuildSystems(Collections.singletonList(BuildSystem.pnc2));
         PncClient client = PncClientFactory.create(config);
-        assertTrue(client instanceof PncClient14);
+        assertTrue(client instanceof PncClient20);
         return client;
     }
 }


### PR DESCRIPTION
Note: This is a quick fix/hack

PNC v2 changed the paths for the REST endpoint. The current release (1.5.0) isn't able to communicate with it and fails with an Exception.

I added a `PncClient` interface, kept the old implementation (for PNC 1), and added a new implementation for PNC v2. I had to change some classes in the model as well as I didn't spend time creating an abstraction that works for both versions.